### PR TITLE
fix: specify targetOrigin in all postMessage calls

### DIFF
--- a/extension/Chrome/content.js
+++ b/extension/Chrome/content.js
@@ -26,14 +26,14 @@ window.addEventListener("message", async (event) => {
                     messageId,
                     success: false,
                     error: response.error
-                }, "*");
+                }, window.location.origin);
             } else {
                 window.postMessage({
                     source: "MOVIX_EXTENSION",
                     messageId,
                     success: true,
                     data: response
-                }, "*");
+                }, window.location.origin);
             }
         } catch (error) {
             window.postMessage({
@@ -41,7 +41,7 @@ window.addEventListener("message", async (event) => {
                 messageId,
                 success: false,
                 error: error.message
-            }, "*");
+            }, window.location.origin);
         }
     }
 });
@@ -55,6 +55,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             source: 'MOVIX_EXTENSION',
             type: 'EXTRACTION_RESULT',
             data: message.data
-        }, '*');
+        }, window.location.origin);
     }
 });

--- a/extension/Chrome/injected.js
+++ b/extension/Chrome/injected.js
@@ -38,7 +38,7 @@ window.movixExtractM3u8 = function(type, url) {
             action: 'EXTRACT_M3U8',
             messageId,
             payload: { type, url }
-        }, '*');
+        }, window.location.origin);
     });
 };
 
@@ -77,7 +77,7 @@ window.movixExtractAllM3u8 = function(sources) {
             action: 'EXTRACT_ALL_M3U8',
             messageId,
             payload: { sources }
-        }, '*');
+        }, window.location.origin);
     });
 };
 
@@ -106,7 +106,7 @@ window.movixDetectEmbeds = function(sources) {
             action: 'DETECT_EMBEDS',
             messageId,
             payload: { sources }
-        }, '*');
+        }, window.location.origin);
     });
 };
 
@@ -134,6 +134,6 @@ window.movixSetupHeaders = function(type, url) {
             action: 'SETUP_HEADERS',
             messageId,
             payload: { type, url }
-        }, '*');
+        }, window.location.origin);
     });
 };

--- a/extension/Firefox/content.js
+++ b/extension/Firefox/content.js
@@ -29,14 +29,14 @@ window.addEventListener("message", async (event) => {
                     messageId,
                     success: false,
                     error: response.error
-                }, "*");
+                }, window.location.origin);
             } else {
                 window.postMessage({
                     source: "MOVIX_EXTENSION",
                     messageId,
                     success: true,
                     data: response
-                }, "*");
+                }, window.location.origin);
             }
         } catch (error) {
             window.postMessage({
@@ -44,7 +44,7 @@ window.addEventListener("message", async (event) => {
                 messageId,
                 success: false,
                 error: error.message
-            }, "*");
+            }, window.location.origin);
         }
     }
 });
@@ -57,6 +57,6 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
             source: 'MOVIX_EXTENSION',
             type: 'EXTRACTION_RESULT',
             data: message.data
-        }, '*');
+        }, window.location.origin);
     }
 });

--- a/extension/Firefox/injected.js
+++ b/extension/Firefox/injected.js
@@ -38,7 +38,7 @@ window.movixExtractM3u8 = function(type, url) {
             action: 'EXTRACT_M3U8',
             messageId,
             payload: { type, url }
-        }, '*');
+        }, window.location.origin);
     });
 };
 
@@ -77,7 +77,7 @@ window.movixExtractAllM3u8 = function(sources) {
             action: 'EXTRACT_ALL_M3U8',
             messageId,
             payload: { sources }
-        }, '*');
+        }, window.location.origin);
     });
 };
 
@@ -106,7 +106,7 @@ window.movixDetectEmbeds = function(sources) {
             action: 'DETECT_EMBEDS',
             messageId,
             payload: { sources }
-        }, '*');
+        }, window.location.origin);
     });
 };
 
@@ -134,6 +134,6 @@ window.movixSetupHeaders = function(type, url) {
             action: 'SETUP_HEADERS',
             messageId,
             payload: { type, url }
-        }, '*');
+        }, window.location.origin);
     });
 };

--- a/src/utils/extensionProxy.ts
+++ b/src/utils/extensionProxy.ts
@@ -60,7 +60,7 @@ export const fetchFromExtension = <T = unknown>(
             action,
             payload: enrichedPayload,
             messageId
-        }, "*");
+        }, window.location.origin);
 
         // Timeout after 10 seconds
         setTimeout(() => {

--- a/userscript/movix.user.js
+++ b/userscript/movix.user.js
@@ -5153,7 +5153,7 @@
                 ? payload.message
                 : payload?.error || String(payload || "Erreur inconnue"),
           },
-      "*",
+      pageWindow.location.origin,
     );
   }
 


### PR DESCRIPTION
Replaces 18 `window.postMessage(..., '*')` calls with `window.location.origin` across extensions (Chrome/Firefox), userscript, and web app to prevent message leaking.